### PR TITLE
Add Map view, POI reorder support, and Wanderlog-lite planning doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,10 @@ For production environments, set environment variables according to your hosting
 
 Contributions are welcome! Please feel free to submit a Pull Request.
 
+## Product Planning
+
+- Wanderlog gap analysis implementation plan: `docs/wanderlog-lite-implementation-plan.md`
+
 ## License
 
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.

--- a/docs/wanderlog-lite-implementation-plan.md
+++ b/docs/wanderlog-lite-implementation-plan.md
@@ -1,0 +1,193 @@
+# Wanderlog Gap Closure Plan (Lightweight)
+
+This document translates the Wanderlog comparison into an implementation-ready plan for DotVacay, optimized for a lightweight and easy-to-use product.
+
+## Goals
+
+1. Keep core planning simple and fast.
+2. Add high-value features without introducing heavy operational complexity.
+3. Preserve Clean Architecture boundaries already used in DotVacay.
+
+---
+
+## Phase 1 — High impact, low complexity (2–3 sprints)
+
+### 1) Functional Map tab in Trip Detail
+
+**User value**
+- Users can switch from timeline to a visual map of all POIs for a trip/day.
+- Faster orientation and daily planning.
+
+**Scope**
+- Add `Map` view toggle on trip detail page.
+- Render trip POIs as markers.
+- Add day filter (`All days` + per-day).
+- Clicking marker highlights corresponding POI card.
+
+**Backend**
+- Reuse existing `GET /PointOfInterest/getAll/{tripId}`.
+- No schema change required.
+
+**Frontend**
+- New standalone `trip-map-view` component.
+- Input: trip + POIs + selected day.
+- Keep existing daily itinerary unchanged.
+
+**Acceptance criteria**
+- Users can open Map view from trip detail.
+- Markers render for all POIs with valid coordinates.
+- Day filter updates visible markers.
+
+---
+
+### 2) Reorder POIs within a day (manual)
+
+**User value**
+- Improves daily plan quality quickly.
+
+**Scope**
+- Drag/drop POIs in a day list.
+- Persist order using existing `TripDayIndex` updates.
+
+**Backend**
+- Reuse `PATCH /PointOfInterest/update/{id}/tripDayIndex`.
+- Add batch endpoint only if needed after performance testing.
+
+**Frontend**
+- Use Angular CDK drag-drop in `trip-day` component.
+- On drop, recalculate and persist indexes.
+
+**Acceptance criteria**
+- Drag/drop changes visual order instantly.
+- Reload keeps order.
+- Failed updates show non-blocking error toast and rollback.
+
+---
+
+### 3) Share UX improvements
+
+**User value**
+- Easier collaboration onboarding.
+
+**Scope**
+- Add “Invite” section in trip detail.
+- Include join instructions and quick copy actions.
+- Keep existing join endpoint and role model.
+
+**Backend**
+- Reuse `POST /Trip/join`.
+
+**Frontend**
+- Add small invite panel/modal.
+- Provide default role selector (`Viewer`, `Editor`).
+
+**Acceptance criteria**
+- Existing member can copy invite guidance quickly.
+- New member can join with clear flow and role selection.
+
+---
+
+## Phase 2 — Lean differentiators (2–3 sprints)
+
+### 4) Lite budget tracking
+
+**User value**
+- Quickly estimate trip spend without complex accounting.
+
+**Scope**
+- Add optional cost fields to POI.
+- Add optional trip budget cap.
+- Show planned total and remaining budget.
+
+**Data model proposal**
+- `PointOfInterest`: `EstimatedCost`, `Currency`.
+- `Trip`: `BudgetAmount`, `BudgetCurrency`.
+
+**Acceptance criteria**
+- Users can set optional costs and budget cap.
+- Trip detail displays totals and remaining amount.
+
+---
+
+### 5) ICS export
+
+**User value**
+- Export itinerary to calendar apps.
+
+**Scope**
+- Add `GET /Trip/{id}/export.ics`.
+- Include POIs with start/end dates.
+
+**Acceptance criteria**
+- Downloaded ICS imports correctly in Google/Apple Calendar.
+
+---
+
+### 6) Lightweight attachments (URL-first)
+
+**User value**
+- Keep booking references and tickets accessible.
+
+**Scope**
+- Start with URL attachments (no file storage yet).
+- Attach links to trip or POI.
+
+**Acceptance criteria**
+- Users can add, edit, delete URL references.
+
+---
+
+## Phase 3 — Optional polish
+
+### 7) Activity feed
+
+- Track key events: POI added/updated/deleted, date changes, list changes.
+- Show compact timeline in trip detail.
+
+### 8) Trip templates
+
+- Duplicate trip as template.
+- Create new trip from template.
+
+---
+
+## Out-of-scope for now (to stay lightweight)
+
+- Deep booking provider integrations.
+- Expense splitting and settlements.
+- Offline-first sync engine.
+- Real-time collaborative cursors/chat.
+- File upload pipeline (S3/Blob + scanning + retention policies).
+
+---
+
+## Recommended implementation order
+
+1. Map tab
+2. Reorder POIs
+3. Invite UX
+4. Lite budget
+5. ICS export
+6. URL attachments
+
+This sequence maximizes user-visible value while minimizing migration and infrastructure risk.
+
+---
+
+## Technical guardrails
+
+- Keep controllers thin and preserve service-layer orchestration.
+- Use existing result pattern (`Success`, `Data`, `Errors`).
+- Prefer additive schema changes with nullable fields.
+- Keep first iterations backend-simple and UI-focused.
+- Avoid touching deprecated `DotVacay.Web`; implement in `DotVacay.WebNg` and API layers.
+
+---
+
+## Definition of done (for each feature)
+
+- API contract documented and version-safe.
+- UI path is discoverable with no new onboarding needed.
+- Basic telemetry/logging for failures.
+- Happy path + at least one failure-path test (where test infrastructure exists).
+- Feature included in release notes.

--- a/src/DotVacay.WebNg/src/app/components/trip-day/trip-day.component.html
+++ b/src/DotVacay.WebNg/src/app/components/trip-day/trip-day.component.html
@@ -45,7 +45,25 @@
     <p class="mt-1 text-xs text-slate-500">Add your first stop to start the day.</p>
   </div>
 
-  <div *ngFor="let poi of pointsOfInterest" class="mb-4">
+  <div *ngFor="let poi of pointsOfInterest; let i = index" class="mb-4">
+    <div class="mb-2 flex justify-end gap-2">
+      <button
+        type="button"
+        class="rounded-lg border border-slate-200 px-2 py-1 text-xs text-slate-500 disabled:opacity-40"
+        [disabled]="i === 0"
+        (click)="movePoi(poi, 'up')"
+      >
+        ↑ Move up
+      </button>
+      <button
+        type="button"
+        class="rounded-lg border border-slate-200 px-2 py-1 text-xs text-slate-500 disabled:opacity-40"
+        [disabled]="i === pointsOfInterest.length - 1"
+        (click)="movePoi(poi, 'down')"
+      >
+        ↓ Move down
+      </button>
+    </div>
     <poi-list-item
       [poi]="poi"
       [currentDate]="currentDate"

--- a/src/DotVacay.WebNg/src/app/components/trip-day/trip-day.component.ts
+++ b/src/DotVacay.WebNg/src/app/components/trip-day/trip-day.component.ts
@@ -21,6 +21,7 @@ export class TripDayComponent implements OnInit {
   @Output() onAddPoi = new EventEmitter<Date>();
   @Output() onRefresh = new EventEmitter<Date>();
   @Output() onEditPoi = new EventEmitter<PointOfInterest>();
+  @Output() onMovePoi = new EventEmitter<{ day: Date, poi: PointOfInterest, direction: 'up' | 'down' }>();
   @Output() onGenerateAiSuggestions = new EventEmitter<{date: Date, location: string}>();
 
   isGeneratingSuggestions: boolean = false;
@@ -93,6 +94,10 @@ export class TripDayComponent implements OnInit {
     this.onEditPoi.emit(poi);
   }
 
+  movePoi(poi: PointOfInterest, direction: 'up' | 'down'): void {
+    this.onMovePoi.emit({ day: this.currentDate, poi, direction });
+  }
+
   generateAiSuggestions(): void {
     this.isGeneratingSuggestions = true;
     this.onGenerateAiSuggestions.emit({
@@ -105,5 +110,4 @@ export class TripDayComponent implements OnInit {
     this.isGeneratingSuggestions = status;
   }
 }
-
 

--- a/src/DotVacay.WebNg/src/app/pages/trip-detail/trip-detail.component.html
+++ b/src/DotVacay.WebNg/src/app/pages/trip-detail/trip-detail.component.html
@@ -45,7 +45,30 @@
       </div>
     </div>
 
-    <div class="relative mt-16 border-l-2 border-slate-100 pb-24 pl-8">
+    <div class="mt-6 inline-flex rounded-2xl border border-slate-200 bg-white p-1 shadow-soft">
+      <button
+        type="button"
+        class="rounded-xl px-4 py-2 text-sm font-semibold transition-all duration-200"
+        [class.bg-brand-500]="activeTab === 'plan'"
+        [class.text-white]="activeTab === 'plan'"
+        [class.text-slate-500]="activeTab !== 'plan'"
+        (click)="setActiveTab('plan')"
+      >
+        Plan
+      </button>
+      <button
+        type="button"
+        class="rounded-xl px-4 py-2 text-sm font-semibold transition-all duration-200"
+        [class.bg-brand-500]="activeTab === 'map'"
+        [class.text-white]="activeTab === 'map'"
+        [class.text-slate-500]="activeTab !== 'map'"
+        (click)="setActiveTab('map')"
+      >
+        Map
+      </button>
+    </div>
+
+    <div class="relative mt-10 border-l-2 border-slate-100 pb-24 pl-8" *ngIf="activeTab === 'plan'">
       <div class="mb-8">
         <h2 class="text-2xl font-black text-slate-900">Daily Itinerary</h2>
         <p class="mt-1 text-sm font-medium text-slate-500">Build a timeline for every day of your trip.</p>
@@ -61,6 +84,7 @@
           (onAddPoi)="openAddPoiModal($event)"
           (onRefresh)="loadTripDetails()"
           (onEditPoi)="openEditPoiModal($event)"
+          (onMovePoi)="movePoiWithinDay($event)"
           (onGenerateAiSuggestions)="generateDayAiSuggestions($event)">
         </trip-day>
       </div>
@@ -72,7 +96,50 @@
       </div>
     </div>
 
-    <div class="mt-16 border-l-2 border-slate-100 pb-24 pl-8">
+    <div class="mt-10 rounded-3xl border border-slate-200 bg-white p-6 shadow-soft" *ngIf="activeTab === 'map'">
+      <div class="mb-4 flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+        <h2 class="text-2xl font-black text-slate-900">Trip Map</h2>
+        <select
+          class="rounded-xl border border-slate-200 px-3 py-2 text-sm text-slate-700"
+          [(ngModel)]="selectedMapDay"
+          (ngModelChange)="setActiveTab('map')"
+        >
+          <option value="all">All days</option>
+          <option *ngFor="let day of tripDays; let i = index" [value]="i">{{ day | date:'EEE, MMM d' }}</option>
+        </select>
+      </div>
+
+      <div *ngIf="getMapPois().length === 0" class="rounded-2xl border border-dashed border-slate-300 bg-slate-50 p-6 text-center text-sm text-slate-500">
+        No POIs with coordinates found for this selection.
+      </div>
+
+      <div *ngIf="getMapPois().length > 0" class="grid gap-4 lg:grid-cols-3">
+        <div class="space-y-2 lg:col-span-1">
+          <button
+            type="button"
+            *ngFor="let poi of getMapPois()"
+            (click)="selectMapPoi(poi)"
+            class="w-full rounded-2xl border px-3 py-2 text-left transition-all duration-200"
+            [class.border-brand-500]="selectedMapPoi?.id === poi.id"
+            [class.bg-brand-50]="selectedMapPoi?.id === poi.id"
+            [class.border-slate-200]="selectedMapPoi?.id !== poi.id"
+          >
+            <p class="font-semibold text-slate-800">{{ poi.title }}</p>
+            <p class="text-xs text-slate-500">{{ poi.startDate | date:'MMM d, h:mm a' }}</p>
+          </button>
+        </div>
+
+        <div class="overflow-hidden rounded-2xl border border-slate-200 lg:col-span-2" *ngIf="selectedMapPoi">
+          <iframe
+            [attr.src]="getSelectedMapUrl()"
+            class="h-[420px] w-full"
+            title="Trip location map"
+          ></iframe>
+        </div>
+      </div>
+    </div>
+
+    <div class="mt-16 border-l-2 border-slate-100 pb-24 pl-8" *ngIf="activeTab === 'plan'">
       <trip-lists-manager [tripId]="tripId"></trip-lists-manager>
     </div>
   </div>
@@ -106,19 +173,31 @@
 </div>
 
 <div class="fixed bottom-0 left-0 right-0 z-[60] flex items-center justify-between border-t border-slate-100 bg-white/90 px-6 py-3 backdrop-blur-lg md:hidden">
-  <a routerLink="/trips" class="flex h-11 flex-col items-center justify-center gap-1 text-brand-500 transition-all duration-300">
+  <button
+    type="button"
+    class="flex h-11 flex-col items-center justify-center gap-1 transition-all duration-300"
+    [class.text-brand-500]="activeTab === 'plan'"
+    [class.text-slate-400]="activeTab !== 'plan'"
+    (click)="setActiveTab('plan')"
+  >
     <svg class="h-6 w-6" viewBox="0 0 24 24" fill="none" stroke="currentColor" aria-hidden="true">
       <path d="M4 6h16M4 12h10M4 18h16" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
     </svg>
     <span class="text-[10px] font-bold uppercase">Plan</span>
-  </a>
-  <button class="flex h-11 flex-col items-center justify-center gap-1 text-slate-400 transition-all duration-300">
+  </button>
+  <button
+    type="button"
+    class="flex h-11 flex-col items-center justify-center gap-1 transition-all duration-300"
+    [class.text-brand-500]="activeTab === 'map'"
+    [class.text-slate-400]="activeTab !== 'map'"
+    (click)="setActiveTab('map')"
+  >
     <svg class="h-6 w-6" viewBox="0 0 24 24" fill="none" stroke="currentColor" aria-hidden="true">
       <path d="M3 11l9-7 9 7-9 7-9-7z" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
     </svg>
     <span class="text-[10px] font-bold uppercase">Map</span>
   </button>
-  <button class="flex h-11 flex-col items-center justify-center gap-1 text-slate-400 transition-all duration-300">
+  <button class="flex h-11 flex-col items-center justify-center gap-1 text-slate-400 transition-all duration-300" type="button" (click)="setActiveTab('plan')">
     <svg class="h-6 w-6" viewBox="0 0 24 24" fill="none" stroke="currentColor" aria-hidden="true">
       <path d="M6 4h9l3 3v13H6z" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
       <path d="M9 8h6M9 12h6M9 16h3" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>

--- a/src/DotVacay.WebNg/src/app/pages/trip-detail/trip-detail.component.ts
+++ b/src/DotVacay.WebNg/src/app/pages/trip-detail/trip-detail.component.ts
@@ -3,21 +3,21 @@ import { CommonModule } from '@angular/common';
 import { ActivatedRoute, Router, RouterModule } from '@angular/router';
 import { TripService } from '../../services/trip.service';
 import { FormsModule } from '@angular/forms';
-import { EditPoiModal } from "../../components/edit-poi-modal/edit-poi-modal.component";
-import { TripDayComponent } from "../../components/trip-day/trip-day.component";
-import { TripListsManagerComponent } from "../../components/trip-lists-manager/trip-lists-manager.component";
-import { ConfirmDialogComponent } from "../../components/confirm-dialog/confirm-dialog.component";
+import { EditPoiModal } from '../../components/edit-poi-modal/edit-poi-modal.component';
+import { TripDayComponent } from '../../components/trip-day/trip-day.component';
+import { TripListsManagerComponent } from '../../components/trip-lists-manager/trip-lists-manager.component';
+import { ConfirmDialogComponent } from '../../components/confirm-dialog/confirm-dialog.component';
 import { PointOfInterest } from '../../models/point-of-interest.model';
-import { AiSuggestionService, PoiSuggestion } from '../../services/ai-suggestion.service';
+import { AiSuggestionService } from '../../services/ai-suggestion.service';
 import { PointOfInterestService } from '../../services/point-of-interest.service';
 
 @Component({
   selector: 'trip-detail',
   standalone: true,
   imports: [
-    CommonModule, 
-    FormsModule, 
-    RouterModule, 
+    CommonModule,
+    FormsModule,
+    RouterModule,
     EditPoiModal,
     TripDayComponent,
     TripListsManagerComponent,
@@ -41,17 +41,15 @@ export class TripDetailComponent implements OnInit {
   selectedDate: Date | null = null;
   isPoiDrawerOpen: boolean = false;
   isDeleteTripConfirmOpen: boolean = false;
-  
-  // Add these properties for AI testing
-  aiTestLoading: boolean = false;
-  aiTestSuccess: boolean = false;
-  aiTestError: string = '';
+  activeTab: 'plan' | 'map' = 'plan';
+  selectedMapDay: string = 'all';
+  selectedMapPoi: PointOfInterest | null = null;
 
   @ViewChildren(TripDayComponent) tripDayComponents!: QueryList<TripDayComponent>;
 
   constructor(
     private route: ActivatedRoute,
-    private router: Router, 
+    private router: Router,
     private tripService: TripService,
     private aiSuggestionService: AiSuggestionService,
     private pointOfInterestService: PointOfInterestService
@@ -74,6 +72,7 @@ export class TripDetailComponent implements OnInit {
           this.userIsOwner = result.userIsOwner;
 
           this.generateTripDays();
+          this.ensureSelectedMapPoi();
         } else if (result.errors?.length) {
           this.errorMessage = result.errors[0];
         }
@@ -91,7 +90,7 @@ export class TripDetailComponent implements OnInit {
     if (this.trip && this.trip.startDate && this.trip.endDate) {
       const startDate = new Date(this.trip.startDate);
       const endDate = new Date(this.trip.endDate);
-      
+
       let currentDate = new Date(startDate);
       while (currentDate <= endDate) {
         this.tripDays.push(new Date(currentDate));
@@ -104,49 +103,55 @@ export class TripDetailComponent implements OnInit {
     if (!this.trip || !this.trip.pointsOfInterest) {
       return [];
     }
-    
+
     const dayStart = new Date(day);
     dayStart.setHours(0, 0, 0, 0);
-    
+
     const dayEnd = new Date(day);
     dayEnd.setHours(23, 59, 59, 999);
-    
-    return this.trip.pointsOfInterest.filter((poi: PointOfInterest) => {
+
+    const dayPois = this.trip.pointsOfInterest.filter((poi: PointOfInterest) => {
       if (!poi.startDate || !poi.endDate) {
-        return false; // Skip POIs without dates
+        return false;
       }
-      
+
       const poiStartDate = new Date(poi.startDate);
       const poiEndDate = new Date(poi.endDate);
 
       return (
-        (poiStartDate >= dayStart && poiStartDate <= dayEnd) || // POI starts on this day
-        (poiEndDate >= dayStart && poiEndDate <= dayEnd) ||     // POI ends on this day
-        (poiStartDate <= dayStart && poiEndDate >= dayEnd)      // POI spans over this day
+        (poiStartDate >= dayStart && poiStartDate <= dayEnd) ||
+        (poiEndDate >= dayStart && poiEndDate <= dayEnd) ||
+        (poiStartDate <= dayStart && poiEndDate >= dayEnd)
       );
+    });
+
+    return dayPois.sort((a: PointOfInterest, b: PointOfInterest) => {
+      const indexA = a.tripDayIndex ?? Number.MAX_SAFE_INTEGER;
+      const indexB = b.tripDayIndex ?? Number.MAX_SAFE_INTEGER;
+      if (indexA !== indexB) {
+        return indexA - indexB;
+      }
+
+      const dateA = a.startDate ? new Date(a.startDate).getTime() : 0;
+      const dateB = b.startDate ? new Date(b.startDate).getTime() : 0;
+      return dateA - dateB;
     });
   }
 
   openAddPoiModal(date: Date): void {
-    this.selectedDate = date; // Set the selected date
-    this.selectedPoi = null; // Clear selected POI when adding new
+    this.selectedDate = date;
+    this.selectedPoi = null;
     this.isPoiDrawerOpen = true;
   }
 
   openEditPoiModal(poi: PointOfInterest): void {
     this.selectedPoi = poi;
-    this.selectedDate = null; // Clear selectedDate when editing existing POI
+    this.selectedDate = null;
     this.isPoiDrawerOpen = true;
   }
 
   closeEditTripModal(): void {
     this.isPoiDrawerOpen = false;
-  }
-
-  deletePointOfInterest(poi: PointOfInterest): void {
-    if (confirm('Are you sure you want to delete this point of interest?')) {
-      this.closeEditTripModal();
-    }
   }
 
   onPoiSaved(result: { success?: boolean } | boolean): void {
@@ -202,51 +207,32 @@ export class TripDetailComponent implements OnInit {
     }
   }
 
-  onPoiCreated(result: any): void {
-    this.successMessage = 'Trip created successfully!';
-    this.loadTripDetails(); 
-    this.closeEditTripModal(); 
-
-    // Clear success message after 5 seconds
-    setTimeout(() => {
-      this.successMessage = '';
-    }, 5000);
-  }
-
-  // This method is called when the AI Suggestions button is clicked on a specific day
-  generateDayAiSuggestions(event: {date: Date, location: string}): void {
-    // Find the corresponding trip day component
+  generateDayAiSuggestions(event: { date: Date, location: string }): void {
     const dayComponent = this.findTripDayComponent(event.date);
-    
-    // Set the component to loading state
+
     if (dayComponent) {
       dayComponent.setGeneratingStatus(true);
     }
 
-    const d = event.date; // local midnight
+    const d = event.date;
     const startDate = new Date(Date.UTC(d.getFullYear(), d.getMonth(), d.getDate(), 0, 0, 0, 0));
     const endDate = new Date(Date.UTC(d.getFullYear(), d.getMonth(), d.getDate(), 23, 59, 59, 999));
-    
-    // Create the request with the specific day's date and trip ID
+
     const request = {
       location: event.location,
       startDate: startDate.toISOString(),
       endDate: endDate.toISOString(),
       tripId: this.tripId
     };
-    
-    // Call the AI suggestion service
+
     this.aiSuggestionService.generateSuggestions(request).subscribe({
-      next: (result) => { 
+      next: (result) => {
         if (result.success) {
-          console.log(`Received ${result.suggestions.length} AI suggestions for ${startDate.toLocaleDateString()}`);
-          // Refresh data to show new POIs
           this.loadTripDetails();
         } else {
           console.error('Failed to generate AI suggestions:', result.errors);
         }
-        
-        // Update UI
+
         if (dayComponent) {
           dayComponent.setGeneratingStatus(false);
         }
@@ -260,17 +246,123 @@ export class TripDetailComponent implements OnInit {
     });
   }
 
-  // Helper method to find the TripDayComponent for a specific date
-  private findTripDayComponent(date: Date): TripDayComponent | undefined {
-    if (!this.tripDayComponents) return undefined;
-    
-    return this.tripDayComponents.find(component => {
-      const componentDate = new Date(component.currentDate);
-      return componentDate.getFullYear() === date.getFullYear() &&
-             componentDate.getMonth() === date.getMonth() &&
-             componentDate.getDate() === date.getDate();
+  async movePoiWithinDay(event: { day: Date, poi: PointOfInterest, direction: 'up' | 'down' }): Promise<void> {
+    const dayPois = [...this.getPointsOfInterestForDay(event.day)];
+    const currentIndex = dayPois.findIndex(poi => poi.id === event.poi.id);
+
+    if (currentIndex < 0) {
+      return;
+    }
+
+    const targetIndex = event.direction === 'up' ? currentIndex - 1 : currentIndex + 1;
+    if (targetIndex < 0 || targetIndex >= dayPois.length) {
+      return;
+    }
+
+    [dayPois[currentIndex], dayPois[targetIndex]] = [dayPois[targetIndex], dayPois[currentIndex]];
+
+    const originalTripDayIndexes = dayPois.map(poi => ({ id: poi.id, tripDayIndex: poi.tripDayIndex }));
+
+    dayPois.forEach((poi, index) => {
+      poi.tripDayIndex = index;
     });
+
+    const updates = dayPois.map((poi, index) =>
+      new Promise<void>((resolve, reject) => {
+        this.pointOfInterestService.updateTripDayIndex(poi.id, index).subscribe({
+          next: (result) => {
+            if (result.success) {
+              resolve();
+              return;
+            }
+            reject(new Error(result.errors?.join(', ') || 'Failed to update order'));
+          },
+          error: () => reject(new Error('Failed to update order'))
+        });
+      })
+    );
+
+    try {
+      await Promise.all(updates);
+      this.successMessage = 'Day order updated';
+      setTimeout(() => this.successMessage = '', 2000);
+      this.loadTripDetails();
+    } catch {
+      originalTripDayIndexes.forEach(original => {
+        const poi = this.trip?.pointsOfInterest?.find((tripPoi: PointOfInterest) => tripPoi.id === original.id);
+        if (poi) {
+          poi.tripDayIndex = original.tripDayIndex;
+        }
+      });
+      this.errorMessage = 'Failed to save the updated order';
+    }
   }
 
-  // Remove the saveSuggestions method as it's no longer needed
+  setActiveTab(tab: 'plan' | 'map'): void {
+    this.activeTab = tab;
+    this.ensureSelectedMapPoi();
+  }
+
+  getMapPois(): PointOfInterest[] {
+    if (!this.trip?.pointsOfInterest) {
+      return [];
+    }
+
+    const allWithCoords = this.trip.pointsOfInterest.filter((poi: PointOfInterest) =>
+      poi.latitude !== undefined && poi.latitude !== null && poi.longitude !== undefined && poi.longitude !== null
+    );
+
+    if (this.selectedMapDay === 'all') {
+      return allWithCoords;
+    }
+
+    const dayIndex = Number(this.selectedMapDay);
+    const day = this.tripDays[dayIndex];
+    if (!day) {
+      return allWithCoords;
+    }
+
+    const dayIds = new Set(this.getPointsOfInterestForDay(day).map(poi => poi.id));
+    return allWithCoords.filter((poi: PointOfInterest) => dayIds.has(poi.id));
+  }
+
+  selectMapPoi(poi: PointOfInterest): void {
+    this.selectedMapPoi = poi;
+  }
+
+  getSelectedMapUrl(): string {
+    const poi = this.selectedMapPoi;
+    if (!poi?.latitude || !poi?.longitude) {
+      return '';
+    }
+
+    const delta = 0.03;
+    const bbox = `${poi.longitude - delta}%2C${poi.latitude - delta}%2C${poi.longitude + delta}%2C${poi.latitude + delta}`;
+    return `https://www.openstreetmap.org/export/embed.html?bbox=${bbox}&layer=mapnik&marker=${poi.latitude}%2C${poi.longitude}`;
+  }
+
+  private ensureSelectedMapPoi(): void {
+    const mapPois = this.getMapPois();
+    if (mapPois.length === 0) {
+      this.selectedMapPoi = null;
+      return;
+    }
+
+    if (!this.selectedMapPoi || !mapPois.some(poi => poi.id === this.selectedMapPoi?.id)) {
+      this.selectedMapPoi = mapPois[0];
+    }
+  }
+
+  private findTripDayComponent(date: Date): TripDayComponent | undefined {
+    if (!this.tripDayComponents) {
+      return undefined;
+    }
+
+    return this.tripDayComponents.find(component => {
+      const componentDate = new Date(component.currentDate);
+      return componentDate.getFullYear() === date.getFullYear()
+        && componentDate.getMonth() === date.getMonth()
+        && componentDate.getDate() === date.getDate();
+    });
+  }
 }

--- a/src/DotVacay.WebNg/src/app/services/point-of-interest.service.ts
+++ b/src/DotVacay.WebNg/src/app/services/point-of-interest.service.ts
@@ -14,6 +14,11 @@ export interface RequestResult {
 })
 export class PointOfInterestService {
   constructor(private apiService: ApiService) { }
+
+  updateTripDayIndex(poiId: string, tripDayIndex: number): Observable<RequestResult> {
+    return this.apiService.patch<RequestResult>(`/PointOfInterest/update/${poiId}/tripDayIndex`, tripDayIndex);
+  }
+
   deletePointOfInterest(poiId: string): Observable<RequestResult> {
     return this.apiService.delete<RequestResult>(`/PointOfInterest/delete/${poiId}`);
   }
@@ -46,6 +51,5 @@ export class PointOfInterestService {
     }
   }
 }
-
 
 


### PR DESCRIPTION
### Motivation

- Provide a visual Map tab to view and select trip POIs on a map for faster orientation and per-day filtering.
- Allow manual reordering of POIs within a day to improve itinerary quality without heavy backend changes.
- Preserve and share the product planning work by adding a lightweight Wanderlog gap-closure implementation plan.

### Description

- UI: add Plan/Map tab toggles in `trip-detail` with a `Trip Map` view, day selector, a POI list, and an embedded OpenStreetMap iframe for the selected POI, and update the mobile bottom navigation to switch tabs.
- POI ordering: add Move up / Move down controls to the `trip-day` template and emit `onMovePoi` events from `TripDayComponent` to the parent `TripDetailComponent`.
- Backend interaction: implement `movePoiWithinDay` in `TripDetailComponent` to compute new `tripDayIndex` values, call the new `PointOfInterestService.updateTripDayIndex` patch endpoint for each POI, and perform rollback on failure, plus sort POIs by `tripDayIndex` (then by start date) in `getPointsOfInterestForDay`.
- Services and docs: add `updateTripDayIndex` to `PointOfInterestService`, add `docs/wanderlog-lite-implementation-plan.md`, and expose a `Product Planning` link in `README.md`.

### Testing

- Executed the frontend build via `ng build` and the application compiled successfully.
- Ran the existing frontend unit test suite via `ng test` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6c37fb8a0832ca48f1587c27be1e4)